### PR TITLE
Add xdg open from remote

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -70,6 +70,7 @@
     - role: tmux
     - role: update
     - role: uv
+    - role: xdg_open
     - role: zoxide
 
     - role: gnome

--- a/roles/xdg_open/defaults/main.yml
+++ b/roles/xdg_open/defaults/main.yml
@@ -1,0 +1,2 @@
+xdg_open_port: 19999
+xdg_open_remote_hosts: ["mrtknecht1", "mrtknecht2", "mrtknecht3", "mrtknecht4", "mrtknecht5", "mrtknecht6", "mrtknecht7", "serverus"]

--- a/roles/xdg_open/handlers/main.yml
+++ b/roles/xdg_open/handlers/main.yml
@@ -1,0 +1,7 @@
+- name: Reload and enable socket
+  ansible.builtin.systemd:
+    name: ssh_remote_xdg_open.socket
+    state: started
+    enabled: true
+    daemon_reload: true
+    scope: user

--- a/roles/xdg_open/tasks/main.yml
+++ b/roles/xdg_open/tasks/main.yml
@@ -1,0 +1,72 @@
+# ── LOCAL MACHINE (has display) ────────────────────────────────────────────────
+
+- name: Check if systemd is available
+  ansible.builtin.shell: command -v systemctl
+  register: systemd_available
+  ignore_errors: true
+  changed_when: false
+
+- when: has_display and systemd_available.rc == 0
+  block:
+    - name: Ensure systemd user service directory
+      ansible.builtin.file:
+        path: "{{ ansible_env.HOME }}/.config/systemd/user"
+        state: directory
+
+    - name: Deploy socket unit
+      ansible.builtin.template:
+        src: ssh_remote_xdg_open.socket.j2
+        dest: "{{ ansible_env.HOME }}/.config/systemd/user/ssh_remote_xdg_open.socket"
+      notify: Reload and enable socket
+
+    - name: Deploy service unit
+      ansible.builtin.template:
+        src: "ssh_remote_xdg_open@.service.j2"
+        dest: "{{ ansible_env.HOME }}/.config/systemd/user/ssh_remote_xdg_open@.service"
+
+    - name: Ensure ~/.ssh directory exists
+      ansible.builtin.file:
+        path: "{{ ansible_env.HOME }}/.ssh"
+        state: directory
+        mode: "0700"
+
+    - name: Ensure ~/.ssh/config exists
+      ansible.builtin.file:
+        path: "{{ ansible_env.HOME }}/.ssh/config"
+        state: touch
+        mode: "0600"
+
+    - name: Add RemoteForward entries to SSH config
+      ansible.builtin.blockinfile:
+        path: "{{ ansible_env.HOME }}/.ssh/config"
+        marker: "# {mark} ANSIBLE MANAGED BLOCK xdg-open {{ item }}"
+        block: "{{ lookup('template', 'ssh_config_block.j2') }}"
+      loop: "{{ xdg_open_remote_hosts }}"
+
+# ── REMOTE MACHINE (no display) ───────────────────────────────────────────────
+
+- when: not has_display
+  block:
+    - name: Find real xdg-open before installing shim
+      ansible.builtin.shell: |
+        for p in /usr/bin/xdg-open /usr/local/bin/xdg-open; do
+          [ -x "$p" ] && echo "$p" && break
+        done
+      register: real_xdg_open_result
+      changed_when: false
+
+    - name: Set real_xdg_open_path fact
+      ansible.builtin.set_fact:
+        real_xdg_open_path: "{{ real_xdg_open_result.stdout | trim }}"
+
+    - name: Ensure ~/.local/bin exists
+      ansible.builtin.file:
+        path: "{{ ansible_env.HOME }}/.local/bin"
+        state: directory
+
+    - name: Deploy xdg-open shim
+      ansible.builtin.template:
+        src: xdg_open_shim.py.j2
+        dest: "{{ ansible_env.HOME }}/.local/bin/xdg-open"
+        mode: "0755"
+      when: real_xdg_open_path | length > 0

--- a/roles/xdg_open/templates/ssh_config_block.j2
+++ b/roles/xdg_open/templates/ssh_config_block.j2
@@ -1,0 +1,2 @@
+Host {{ item }}
+  RemoteForward 127.0.0.1:{{ xdg_open_port }} /run/user/{{ ansible_facts['user_uid'] }}/ssh_remote_xdg_open.sock

--- a/roles/xdg_open/templates/ssh_remote_xdg_open.socket.j2
+++ b/roles/xdg_open/templates/ssh_remote_xdg_open.socket.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Local "open URL" socket for ssh-remote-xdg-open
+
+[Socket]
+ListenStream=/run/user/{{ ansible_facts['user_uid'] }}/ssh_remote_xdg_open.sock
+SocketMode=0600
+Accept=yes
+
+[Install]
+WantedBy=default.target

--- a/roles/xdg_open/templates/ssh_remote_xdg_open@.service.j2
+++ b/roles/xdg_open/templates/ssh_remote_xdg_open@.service.j2
@@ -1,0 +1,6 @@
+[Unit]
+Description=Local "open URL" service instance
+
+[Service]
+ExecStart=/bin/sh -lc 'xargs -0 -n1 xdg-open'
+StandardInput=socket

--- a/roles/xdg_open/templates/xdg_open_shim.py.j2
+++ b/roles/xdg_open/templates/xdg_open_shim.py.j2
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import socket
+import sys
+import os
+
+PORT = int(os.environ.get("OPEN_LOCAL_PORT", {{ xdg_open_port }}))
+REAL_XDG_OPEN = "{{ real_xdg_open_path }}"
+
+def fallback(url):
+    os.execv(REAL_XDG_OPEN, [REAL_XDG_OPEN, url])
+
+def rewrite(url):
+    import socket as s
+    hostname = s.gethostname()
+    url = url.replace("localhost", hostname)
+    url = url.replace("127.0.0.1", hostname)
+    return url
+
+if len(sys.argv) < 2:
+    sys.exit(1)
+
+original_url = sys.argv[1]
+rewritten_url = rewrite(original_url)
+
+try:
+    s = socket.create_connection(("127.0.0.1", PORT), timeout=3)
+    s.sendall(rewritten_url.encode() + b"\x00")
+    s.close()
+except Exception:
+    fallback(original_url)


### PR DESCRIPTION
This sets up a reverse ssh tunnel on remote machines to forward xdg-open requests to the browser of the local machine.

The inspiration has been taken from [this blog post](https://blog.rymcg.tech/blog/linux/ssh-remote-xdg-open/).