### PR TITLE
Add xdg open from remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ To also deploy tasks that require root privileges, use:
 ansible-pull -U https://github.com/ll-nick/ansible-config.git --tags all,privileged --ask-become-pass
 ```
 
+To run individual roles, specify the role name as a tag (e.g. `--tags neovim`).
+
 For first time usage, there is also a [bash script](deploy/deploy.sh) that can be used
  to interactively install the required dependencies (including ansible itself), then execute the playbook.
 I host that script using the accompanying Docker file to set everything up in one go using `curl mydomain.com | bash`.

--- a/local.yml
+++ b/local.yml
@@ -70,6 +70,7 @@
     - role: tmux
     - role: update
     - role: uv
+    - role: xdg_open
     - role: zoxide
 
     - role: gnome

--- a/local.yml
+++ b/local.yml
@@ -15,70 +15,96 @@
 - name: Full setup
   hosts: local
   pre_tasks:
-    - name: Check if host has a display
-      set_fact:
-        has_display: >-
-          {{
-            (ansible_facts['env']['DISPLAY'] is defined
-             and ansible_facts['env']['DISPLAY'] is match('^:[0-9]+$'))
-            or
-            (ansible_facts['env']['WAYLAND_DISPLAY'] is defined
-             and ansible_facts['env']['WAYLAND_DISPLAY'] | length > 0)
-          }}
-    - debug:
-        msg: >-
-          {{
-            "Host has a display" if has_display
-            else "Host does not have a display"
-          }}
+    - tags: always
+      block:
+        - name: Check if host has a display
+          set_fact:
+            has_display: >-
+              {{
+                (ansible_facts['env']['DISPLAY'] is defined
+                 and ansible_facts['env']['DISPLAY'] is match('^:[0-9]+$'))
+                or
+                (ansible_facts['env']['WAYLAND_DISPLAY'] is defined
+                 and ansible_facts['env']['WAYLAND_DISPLAY'] | length > 0)
+              }}
+        - debug:
+            msg: >-
+              {{
+                "Host has a display" if has_display
+                else "Host does not have a display"
+              }}
 
-    - name: Check GitHub SSH access
-      shell: ssh -T git@github.com
-      register: github_ssh_test
-      failed_when: false
-      changed_when: false
-    - name: Set GitHub prefix
-      set_fact:
-        github_prefix: >-
-          {{
-            "git@github.com:"
-            if github_ssh_test.rc in [0, 1]
-            else "https://github.com/"
-          }}
-    - debug:
-        msg: "GitHub prefix set to {{ github_prefix }}"
+        - name: Check GitHub SSH access
+          shell: ssh -T git@github.com
+          register: github_ssh_test
+          failed_when: false
+          changed_when: false
+        - name: Set GitHub prefix
+          set_fact:
+            github_prefix: >-
+              {{
+                "git@github.com:"
+                if github_ssh_test.rc in [0, 1]
+                else "https://github.com/"
+              }}
+        - debug:
+            msg: "GitHub prefix set to {{ github_prefix }}"
 
 
   roles:
     - role: mise
+      tags: mise
 
     - role: bash
+      tags: bash
     - role: nushell
+      tags: nushell
 
     - role: bat
+      tags: bat
     - role: eza
+      tags: eza
     - role: fd
+      tags: fd
     - role: fzf
+      tags: fzf
     - role: git
+      tags: git
     - role: lazygit
+      tags: lazygit
     - role: leadr
+      tags: leadr
     - role: locale
+      tags: locale
     - role: neovim
+      tags: neovim
     - role: nodejs
+      tags: nodejs
     - role: ripgrep
+      tags: ripgrep
     - role: starship
+      tags: starship
     - role: tmux
+      tags: tmux
     - role: update
+      tags: update
     - role: uv
+      tags: uv
     - role: xdg_open
+      tags: xdg_open
     - role: zoxide
+      tags: zoxide
 
     - role: gnome
       when: has_display
+      tags: gnome
     - role: kitty
       when: has_display
+      tags: kitty
     - role: nerdfont
       when: has_display
+      tags: nerdfont
 
     - role: mrt
       when: "'mrt' in ansible_hostname"
+      tags: mrt

--- a/roles/xdg_open/README.md
+++ b/roles/xdg_open/README.md
@@ -1,0 +1,27 @@
+# xdg_open
+
+Forwards `xdg-open` calls from remote servers to the local machine's browser via an SSH reverse tunnel.
+
+## How it works
+
+**Local machine** (`has_display: true`): two systemd user units create a Unix socket that runs `xdg-open` on each incoming connection.
+SSH `RemoteForward` exposes this socket as a TCP port on each remote host.
+
+**Remote machine** (`has_display: false`): a Python shim is installed at `~/.local/bin/xdg-open` (takes priority over `/usr/bin/xdg-open`).
+It rewrites `localhost`/`127.0.0.1` in URLs to the remote's hostname, then forwards the URL through the tunnel.
+Falls back to the real `xdg-open` if the tunnel is unavailable.
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `xdg_open_port` | `19999` | TCP port used by `RemoteForward` |
+| `xdg_open_open_cmd` | `flatpak run org.mozilla.firefox` | Command used to open URLs on the local machine |
+
+`RemoteForward` entries are injected into **all existing `Host` blocks** in `~/.ssh/config` automatically.
+
+## Caveats
+
+- **Webserver bind address**: preview plugins (e.g. markdown-preview.nvim) must bind to `0.0.0.0`, not `127.0.0.1`, so the rewritten hostname URL is reachable. Configure this per plugin (`g:mkdp_open_to_the_world = 1` for markdown-preview.nvim).
+- **Tunnel lifetime**: `RemoteForward` only exists for the duration of the SSH session. If a tmux session outlives the connection, the shim falls back to the real `xdg-open` on the remote (typically a no-op on headless servers).
+- **`xdg_open_open_cmd`**: `xdg-open` and `gio open` do not work from systemd service context with Flatpak browsers. Use `flatpak run <app-id>` directly, or `gtk-launch` for non-Flatpak browsers.

--- a/roles/xdg_open/defaults/main.yml
+++ b/roles/xdg_open/defaults/main.yml
@@ -1,0 +1,1 @@
+xdg_open_port: 19999

--- a/roles/xdg_open/defaults/main.yml
+++ b/roles/xdg_open/defaults/main.yml
@@ -1,1 +1,2 @@
 xdg_open_port: 19999
+xdg_open_open_cmd: "flatpak run org.mozilla.firefox"

--- a/roles/xdg_open/files/inject_remote_forward.py
+++ b/roles/xdg_open/files/inject_remote_forward.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Inject RemoteForward into every Host block in ~/.ssh/config.
+
+Usage: inject_remote_forward.py <port> <socket_path>
+
+Idempotent: skips blocks that already have a RemoteForward on the given port.
+Skips 'Host *' and 'Match' blocks.
+"""
+import os
+import re
+import sys
+
+port = sys.argv[1]
+socket_path = sys.argv[2]
+forward_line = f"  RemoteForward 127.0.0.1:{port} {socket_path}\n"
+marker = f"RemoteForward 127.0.0.1:{port}"
+
+config_path = os.path.expanduser("~/.ssh/config")
+if not os.path.exists(config_path):
+    sys.exit(0)
+
+with open(config_path) as f:
+    lines = f.readlines()
+
+result = []
+changed = False
+i = 0
+
+while i < len(lines):
+    line = lines[i]
+    m = re.match(r'^Host\s+(.+)', line, re.IGNORECASE)
+    if m and m.group(1).strip() != '*':
+        # Collect the block (lines until next Host/Match keyword)
+        block = []
+        j = i + 1
+        while j < len(lines) and not re.match(r'^(Host|Match)\s+', lines[j], re.IGNORECASE):
+            block.append(lines[j])
+            j += 1
+        result.append(line)
+        if not any(marker in bl for bl in block):
+            result.append(forward_line)
+            changed = True
+        result.extend(block)
+        i = j
+    else:
+        result.append(line)
+        i += 1
+
+if changed:
+    with open(config_path, "w") as f:
+        f.writelines(result)
+    sys.exit(2)  # signal "changed" to Ansible

--- a/roles/xdg_open/handlers/main.yml
+++ b/roles/xdg_open/handlers/main.yml
@@ -1,0 +1,7 @@
+- name: Reload and enable socket
+  ansible.builtin.systemd:
+    name: ssh_remote_xdg_open.socket
+    state: started
+    enabled: true
+    daemon_reload: true
+    scope: user

--- a/roles/xdg_open/tasks/main.yml
+++ b/roles/xdg_open/tasks/main.yml
@@ -24,24 +24,16 @@
         src: "ssh_remote_xdg_open@.service.j2"
         dest: "{{ ansible_env.HOME }}/.config/systemd/user/ssh_remote_xdg_open@.service"
 
-    - name: Ensure ~/.ssh directory exists
-      ansible.builtin.file:
-        path: "{{ ansible_env.HOME }}/.ssh"
-        state: directory
-        mode: "0700"
-
-    - name: Ensure ~/.ssh/config exists
-      ansible.builtin.file:
-        path: "{{ ansible_env.HOME }}/.ssh/config"
-        state: touch
-        mode: "0600"
-
-    - name: Add RemoteForward entries to SSH config
-      ansible.builtin.blockinfile:
-        path: "{{ ansible_env.HOME }}/.ssh/config"
-        marker: "# {mark} ANSIBLE MANAGED BLOCK xdg-open {{ item }}"
-        block: "{{ lookup('template', 'ssh_config_block.j2') }}"
-      loop: "{{ xdg_open_remote_hosts }}"
+    - name: Inject RemoteForward into SSH config
+      ansible.builtin.script:
+        cmd: >
+          inject_remote_forward.py
+          {{ xdg_open_port }}
+          /run/user/{{ ansible_facts['user_uid'] }}/ssh_remote_xdg_open.sock
+        executable: python3
+      register: inject_result
+      changed_when: inject_result.rc == 2
+      failed_when: inject_result.rc not in [0, 2]
 
 # ── REMOTE MACHINE (no display) ───────────────────────────────────────────────
 

--- a/roles/xdg_open/tasks/main.yml
+++ b/roles/xdg_open/tasks/main.yml
@@ -1,0 +1,72 @@
+# ── LOCAL MACHINE (has display) ────────────────────────────────────────────────
+
+- name: Check if systemd is available
+  ansible.builtin.shell: command -v systemctl
+  register: systemd_available
+  ignore_errors: true
+  changed_when: false
+
+- when: has_display and systemd_available.rc == 0
+  block:
+    - name: Ensure systemd user service directory
+      ansible.builtin.file:
+        path: "{{ ansible_env.HOME }}/.config/systemd/user"
+        state: directory
+
+    - name: Deploy socket unit
+      ansible.builtin.template:
+        src: ssh_remote_xdg_open.socket.j2
+        dest: "{{ ansible_env.HOME }}/.config/systemd/user/ssh_remote_xdg_open.socket"
+      notify: Reload and enable socket
+
+    - name: Deploy service unit
+      ansible.builtin.template:
+        src: "ssh_remote_xdg_open@.service.j2"
+        dest: "{{ ansible_env.HOME }}/.config/systemd/user/ssh_remote_xdg_open@.service"
+
+    - name: Ensure ~/.ssh directory exists
+      ansible.builtin.file:
+        path: "{{ ansible_env.HOME }}/.ssh"
+        state: directory
+        mode: "0700"
+
+    - name: Ensure ~/.ssh/config exists
+      ansible.builtin.file:
+        path: "{{ ansible_env.HOME }}/.ssh/config"
+        state: touch
+        mode: "0600"
+
+    - name: Add RemoteForward entries to SSH config
+      ansible.builtin.blockinfile:
+        path: "{{ ansible_env.HOME }}/.ssh/config"
+        marker: "# {mark} ANSIBLE MANAGED BLOCK xdg-open {{ item }}"
+        block: "{{ lookup('template', 'ssh_config_block.j2') }}"
+      loop: "{{ xdg_open_remote_hosts }}"
+
+# ── REMOTE MACHINE (no display) ───────────────────────────────────────────────
+
+- when: not has_display
+  block:
+    - name: Find real xdg-open before installing shim
+      ansible.builtin.shell: |
+        for p in /usr/bin/xdg-open /usr/local/bin/xdg-open; do
+          [ -x "$p" ] && echo "$p" && break
+        done
+      register: real_xdg_open_result
+      changed_when: false
+
+    - name: Set real_xdg_open_path fact
+      ansible.builtin.set_fact:
+        real_xdg_open_path: "{{ real_xdg_open_result.stdout | trim }}"
+
+    - name: Ensure ~/.local/bin exists
+      ansible.builtin.file:
+        path: "{{ ansible_env.HOME }}/.local/bin"
+        state: directory
+
+    - name: Deploy xdg-open shim
+      ansible.builtin.template:
+        src: xdg_open_shim.py.j2
+        dest: "{{ ansible_env.HOME }}/.local/bin/xdg-open"
+        mode: "0755"
+      when: real_xdg_open_path | length > 0

--- a/roles/xdg_open/templates/ssh_config_block.j2
+++ b/roles/xdg_open/templates/ssh_config_block.j2
@@ -1,2 +1,0 @@
-Host {{ item }}
-  RemoteForward 127.0.0.1:{{ xdg_open_port }} /run/user/{{ ansible_facts['user_uid'] }}/ssh_remote_xdg_open.sock

--- a/roles/xdg_open/templates/ssh_config_block.j2
+++ b/roles/xdg_open/templates/ssh_config_block.j2
@@ -1,0 +1,2 @@
+Host {{ item }}
+  RemoteForward 127.0.0.1:{{ xdg_open_port }} /run/user/{{ ansible_facts['user_uid'] }}/ssh_remote_xdg_open.sock

--- a/roles/xdg_open/templates/ssh_remote_xdg_open.socket.j2
+++ b/roles/xdg_open/templates/ssh_remote_xdg_open.socket.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Local "open URL" socket for ssh-remote-xdg-open
+
+[Socket]
+ListenStream=/run/user/{{ ansible_facts['user_uid'] }}/ssh_remote_xdg_open.sock
+SocketMode=0600
+Accept=yes
+
+[Install]
+WantedBy=default.target

--- a/roles/xdg_open/templates/ssh_remote_xdg_open@.service.j2
+++ b/roles/xdg_open/templates/ssh_remote_xdg_open@.service.j2
@@ -1,0 +1,6 @@
+[Unit]
+Description=Local "open URL" service instance
+
+[Service]
+ExecStart=/bin/sh -lc 'xargs -0 -n1 xdg-open'
+StandardInput=socket

--- a/roles/xdg_open/templates/ssh_remote_xdg_open@.service.j2
+++ b/roles/xdg_open/templates/ssh_remote_xdg_open@.service.j2
@@ -2,5 +2,5 @@
 Description=Local "open URL" service instance
 
 [Service]
-ExecStart=/bin/sh -lc 'xargs -0 -n1 xdg-open'
+ExecStart=/bin/bash -c 'IFS= read -r -d "" url && {{ xdg_open_open_cmd }} "$url"'
 StandardInput=socket

--- a/roles/xdg_open/templates/xdg_open_shim.py.j2
+++ b/roles/xdg_open/templates/xdg_open_shim.py.j2
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import socket
+import sys
+import os
+
+PORT = int(os.environ.get("OPEN_LOCAL_PORT", {{ xdg_open_port }}))
+REAL_XDG_OPEN = "{{ real_xdg_open_path }}"
+
+def fallback(url):
+    os.execv(REAL_XDG_OPEN, [REAL_XDG_OPEN, url])
+
+def rewrite(url):
+    import socket as s
+    hostname = s.gethostname()
+    url = url.replace("localhost", hostname)
+    url = url.replace("127.0.0.1", hostname)
+    return url
+
+if len(sys.argv) < 2:
+    sys.exit(1)
+
+original_url = sys.argv[1]
+rewritten_url = rewrite(original_url)
+
+try:
+    s = socket.create_connection(("127.0.0.1", PORT), timeout=3)
+    s.sendall(rewritten_url.encode() + b"\x00")
+    s.close()
+except Exception:
+    fallback(original_url)


### PR DESCRIPTION
This sets up a reverse ssh tunnel on remote machines to forward xdg-open requests to the browser of the local machine.

The inspiration has been taken from [this blog post](https://blog.rymcg.tech/blog/linux/ssh-remote-xdg-open/).