### PR TITLE
Add test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test-ubuntu:
+    name: Deploy on Ubuntu
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build CI image
+        run: ci/run.sh build
+
+      - name: Run deploy (first pass)
+        run: ci/run.sh deploy /tmp/ci-home
+
+      - name: Verify installed tools and configs
+        run: ci/run.sh verify /tmp/ci-home
+
+      - name: Idempotency check (second pass)
+        run: ci/run.sh idempotency /tmp/ci-home

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ It is designed to install as many tools as possible on the user level and
 A very limited amount of tasks require root privileges for system-wide installation of basic dependencies which can be deployed using the `privileged` tag, see below.
 Running the playbook without these privileges expects those packages to be installed already.
 
-The config is tested on
+The config [continuously tested on the latest Ubuntu](https://github.com/ll-nick/ansible-config/actions/workflows/ci.yml).
+It is also known to work on the following distributions:
 - Arch Linux
 - NixOS[^1]
-- Ubuntu 24.04
 
 [^1]: kitty needs to be installed via nixpkgs.
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,3 +7,4 @@ stdout_callback = pretty_output
 bin_ansible_callbacks = True
 
 force_color = True
+interpreter_python = auto_silent

--- a/callback_plugins/pretty_output.py
+++ b/callback_plugins/pretty_output.py
@@ -89,6 +89,20 @@ class CallbackModule(CallbackBase):
                 f"    → Task failed without error message.", color=C.COLOR_ERROR
             )
 
+    def v2_playbook_on_warning(self, warning):
+        formatted_msg = f"⚠ {warning}"
+        border = "─" * (len(formatted_msg) + 3)
+        top = stringc(f" ┌{border}┐", C.COLOR_WARN)
+        middle = (
+            stringc(" │ ", C.COLOR_WARN)
+            + stringc(formatted_msg, C.COLOR_CONSOLE_PROMPT)
+            + stringc(" │", C.COLOR_WARN)
+        )
+        bottom = stringc(f" └{border}┘", C.COLOR_WARN)
+        self._display.display(top)
+        self._display.display(middle)
+        self._display.display(bottom)
+
     def v2_runner_on_skipped(self, result):
         self.task_counts["skipped"] += 1
         self._print_task_line("skipped", C.COLOR_SKIP)

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl git sudo ca-certificates \
+    && rm -rf /var/lib/apt/lists/*

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl git sudo ca-certificates \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -57,13 +57,12 @@ ci_idempotency() {
         -v "$CACHE_DIR:/root" \
         -e ANSIBLE_BECOME_PASS="" \
         -e DEBIAN_FRONTEND=noninteractive \
-        -e ANSIBLE_STDOUT_CALLBACK=default \
         "$IMAGE" \
         bash -c '
             export PATH="$HOME/.local/bin:$HOME/.local/share/mise/shims:$PATH"
             cd /workspace
             ansible-playbook local.yml 2>&1 | tee /tmp/idempotency.txt
-            grep -E "changed=0\s" /tmp/idempotency.txt \
+            grep -qE "✱ Changed +\| +0" /tmp/idempotency.txt \
                 || { echo "FAIL: playbook is not idempotent"; exit 1; }
             echo "Idempotency check passed."
         '

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -38,7 +38,7 @@ ci_verify() {
         "$IMAGE" \
         bash -c '
             export PATH="$HOME/.local/bin:$HOME/.local/share/mise/shims:$PATH"
-            for tool in mise bat eza fd fzf rg starship zoxide; do
+            for tool in mise bat delta eza fd fzf lazygit leadr node nvim nu rg starship stk tmux uv zoxide; do
                 command -v "$tool" || { echo "MISSING binary: $tool"; exit 1; }
             done
             for config in \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Usage:
+#   ci/run.sh [build|deploy|verify|idempotency|all] [cache-dir]
+#
+# Defaults: command=all, cache-dir=~/.cache/ansible-ci-home
+#
+# Examples:
+#   ci/run.sh                          # full local run
+#   ci/run.sh deploy ~/.cache/ci       # deploy only, custom cache
+#   ci/run.sh build                    # rebuild image only
+
+set -e
+
+COMMAND="${1:-all}"
+CACHE_DIR="${2:-$HOME/.cache/ansible-ci-home}"
+WORKSPACE="$(cd "$(dirname "$0")/.." && pwd)"
+IMAGE="ansible-ci"
+
+ci_build() {
+    docker build -f "$WORKSPACE/ci/Dockerfile" -t "$IMAGE" "$WORKSPACE"
+}
+
+ci_deploy() {
+    mkdir -p "$CACHE_DIR"
+    docker run --rm \
+        -v "$WORKSPACE:/workspace:ro" \
+        -v "$CACHE_DIR:/root" \
+        -e ANSIBLE_BECOME_PASS="" \
+        -e DEBIAN_FRONTEND=noninteractive \
+        "$IMAGE" \
+        bash /workspace/deploy/deploy.sh --no-confirm --privileged --playbook-path /workspace
+}
+
+ci_verify() {
+    docker run --rm \
+        -v "$WORKSPACE:/workspace:ro" \
+        -v "$CACHE_DIR:/root" \
+        "$IMAGE" \
+        bash -c '
+            export PATH="$HOME/.local/bin:$HOME/.local/share/mise/shims:$PATH"
+            for tool in mise bat eza fd fzf rg starship zoxide; do
+                command -v "$tool" || { echo "MISSING binary: $tool"; exit 1; }
+            done
+            for config in \
+                "$HOME/.config/bat/config" \
+                "$HOME/.config/nushell" \
+                "$HOME/.config/starship"; do
+                [ -e "$config" ] || { echo "MISSING config: $config"; exit 1; }
+            done
+            echo "All checks passed."
+        '
+}
+
+ci_idempotency() {
+    docker run --rm \
+        -v "$WORKSPACE:/workspace:ro" \
+        -v "$CACHE_DIR:/root" \
+        -e ANSIBLE_BECOME_PASS="" \
+        -e DEBIAN_FRONTEND=noninteractive \
+        -e ANSIBLE_STDOUT_CALLBACK=default \
+        "$IMAGE" \
+        bash -c '
+            export PATH="$HOME/.local/bin:$HOME/.local/share/mise/shims:$PATH"
+            cd /workspace
+            ansible-playbook local.yml 2>&1 | tee /tmp/idempotency.txt
+            grep -E "changed=0\s" /tmp/idempotency.txt \
+                || { echo "FAIL: playbook is not idempotent"; exit 1; }
+            echo "Idempotency check passed."
+        '
+}
+
+case "$COMMAND" in
+    build) ci_build ;;
+    deploy) ci_deploy ;;
+    verify) ci_verify ;;
+    idempotency) ci_idempotency ;;
+    all)
+        ci_build
+        ci_deploy
+        ci_verify
+        ci_idempotency
+        ;;
+    *)
+        printf "Unknown command: %s\n" "$COMMAND"
+        printf "Usage: %s [build|deploy|verify|idempotency|all] [cache-dir]\n" "$0"
+        exit 1
+        ;;
+esac

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -4,6 +4,7 @@ set -e
 
 NO_CONFIRM=false
 PRIVILEGED_MODE=""
+PLAYBOOK_PATH=""
 
 COLOR_TITLE='\033[1;34m'   # Bold Blue
 COLOR_INFO='\033[0;36m'    # Cyan
@@ -17,10 +18,11 @@ print_help() {
 Usage: $(basename "$0") [OPTIONS]
 
 Options:
-  -y, --no-confirm   Automatically answer yes to all prompts.
-  --privileged       Run ansible-pull with sudo privileges (non-interactive).
-  --unprivileged     Run ansible-pull without sudo privileges (non-interactive).
-  -h, --help         Show this help message and exit.
+  -y, --no-confirm          Automatically answer yes to all prompts.
+  --privileged              Run ansible with sudo privileges (non-interactive).
+  --unprivileged            Run ansible without sudo privileges (non-interactive).
+  --playbook-path <dir>     Run ansible-playbook from a local directory instead of ansible-pull.
+  -h, --help                Show this help message and exit.
 EOF
 }
 
@@ -164,7 +166,7 @@ install_ansible_galaxy_collection() {
 
 run_ansible() {
     if ! confirm "Do you wish to execute the playbook?"; then
-        printf "  ${COLOR_WARN}⚠ Skipping ansible-pull execution.${COLOR_RESET}\n"
+        printf "  ${COLOR_WARN}⚠ Skipping ansible execution.${COLOR_RESET}\n"
         exit 1
     fi
 
@@ -178,22 +180,36 @@ run_ansible() {
     fi
 
     if [ -z "$PRIVILEGED_MODE" ]; then
-        if confirm "Do you want to run ansible-pull with sudo privileges?"; then
+        if confirm "Do you want to run ansible with sudo privileges?"; then
             PRIVILEGED_MODE=true
         else
             PRIVILEGED_MODE=false
         fi
     fi
 
-    if [ "$PRIVILEGED_MODE" = true ]; then
-        printf "  ${COLOR_INFO}⬆ Running ansible-pull with sudo privileges...${COLOR_RESET}\n"
-        ansible-pull -U https://github.com/ll-nick/ansible-config.git --tags all,privileged -K
+    if [ -n "$PLAYBOOK_PATH" ]; then
+        printf "  ${COLOR_INFO}📂 Running ansible-playbook from local path: %s${COLOR_RESET}\n" "$PLAYBOOK_PATH"
+        cd "$PLAYBOOK_PATH"
+        if [ "$PRIVILEGED_MODE" = true ]; then
+            if [ -n "${ANSIBLE_BECOME_PASS+x}" ]; then
+                ansible-playbook local.yml --tags all,privileged
+            else
+                ansible-playbook local.yml --tags all,privileged -K
+            fi
+        else
+            ansible-playbook local.yml
+        fi
     else
-        printf "  ${COLOR_INFO}⬇ Running ansible-pull without sudo privileges...${COLOR_RESET}\n"
-        ansible-pull -U https://github.com/ll-nick/ansible-config.git
+        if [ "$PRIVILEGED_MODE" = true ]; then
+            printf "  ${COLOR_INFO}⬆ Running ansible-pull with sudo privileges...${COLOR_RESET}\n"
+            ansible-pull -U https://github.com/ll-nick/ansible-config.git --tags all,privileged -K
+        else
+            printf "  ${COLOR_INFO}⬇ Running ansible-pull without sudo privileges...${COLOR_RESET}\n"
+            ansible-pull -U https://github.com/ll-nick/ansible-config.git
+        fi
     fi
 
-    printf "  ${COLOR_SUCCESS}✔ ansible-pull execution completed.${COLOR_RESET}\n"
+    printf "  ${COLOR_SUCCESS}✔ Ansible execution completed.${COLOR_RESET}\n"
 }
 
 main() {
@@ -210,6 +226,14 @@ main() {
             --unprivileged)
                 PRIVILEGED_MODE=false
                 shift
+                ;;
+            --playbook-path)
+                if [ -z "$2" ]; then
+                    printf "${COLOR_ERROR}✖ --playbook-path requires a directory argument.${COLOR_RESET}\n"
+                    exit 1
+                fi
+                PLAYBOOK_PATH="$2"
+                shift 2
                 ;;
             -h | --help)
                 print_help
@@ -240,7 +264,7 @@ main() {
     ensure_mise_packages
     install_ansible_galaxy_collection
 
-    print_header "🚀 Running ansible-pull"
+    print_header "🚀 Running ansible"
     run_ansible
 
     printf "\n${COLOR_SUCCESS}✔ Deployment completed successfully!${COLOR_RESET}\n"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -124,7 +124,7 @@ ensure_mise() {
 }
 
 activate_mise() {
-    eval "$($HOME/.local/bin/mise activate --shims)"
+    eval "$($HOME/.local/bin/mise activate bash --shims)"
     printf "  ${COLOR_SUCCESS}✔ mise activated.${COLOR_RESET}\n"
 }
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -28,7 +28,9 @@ EOF
 
 print_header() {
     local title="$1"
-    local width=$((${#title} + 3)) # For some reason this works with piping this script to bash but not with sh
+    local char_count
+    char_count=$(printf '%s' "$title" | LC_ALL=C.UTF-8 wc -m)
+    local width=$((char_count + 3))
     local top="╭$(printf '─%.0s' $(seq 1 $width))╮"
     local bottom="╰$(printf '─%.0s' $(seq 1 $width))╯"
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -128,35 +128,26 @@ ensure_mise_packages() {
     local CONF_D="$HOME/.config/mise/conf.d"
 
     if [ -d "$HOME/.local/share/mise/installs/python" ] &&
-        [ -d "$HOME/.local/share/mise/installs/uv" ] &&
-        [ -d "$HOME/.local/share/mise/installs/ansible" ]; then
+        command -v ansible > /dev/null 2>&1; then
         printf "  ${COLOR_SUCCESS}✔ Required tools are already installed via mise.${COLOR_RESET}\n"
         return
     fi
 
-    if ! confirm "Do you want to install required tools (python, uv, ansible) using mise?"; then
+    if ! confirm "Do you want to install required tools (python, pipx, ansible) using mise?"; then
         printf "  ${COLOR_ERROR}✖ ERROR: Required tools are not installed.${COLOR_RESET}\n"
         exit 1
     fi
 
     mkdir -p "$CONF_D"
 
-    cat > "$CONF_D/python.toml" << 'EOF'
-[tools]
-python = { version = "latest", install_env = { MISE_PYTHON_COMPILE = "false" } }
-EOF
-
-    cat > "$CONF_D/uv.toml" << 'EOF'
-[tools]
-uv = "latest"
-EOF
-
     cat > "$CONF_D/ansible.toml" << 'EOF'
 [tools]
+python = { version = "latest", install_env = { MISE_PYTHON_COMPILE = "false" } }
+pipx = "latest"
 ansible = "latest"
 EOF
 
-    printf "  ${COLOR_INFO}⬇ Installing required tools via mise...${COLOR_RESET}\n"
+    printf "  ${COLOR_INFO}⬇ Installing mise packages...${COLOR_RESET}\n"
     mise install
     printf "  ${COLOR_SUCCESS}✔ Required tools installed.${COLOR_RESET}\n"
 }

--- a/local.yml
+++ b/local.yml
@@ -106,5 +106,5 @@
       tags: nerdfont
 
     - role: mrt
-      when: "'mrt' in ansible_hostname"
+      when: "'mrt' in ansible_facts['hostname']"
       tags: mrt

--- a/roles/bash/tasks/main.yml
+++ b/roles/bash/tasks/main.yml
@@ -1,37 +1,37 @@
 - name: Clone config
   ansible.builtin.git:
     repo: "{{ github_prefix }}ll-nick/bash-config"
-    dest: "{{ ansible_env.HOME }}/.config/bash"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/bash"
   ignore_errors: true
 
 - name: Create bashrc symlink
   ansible.builtin.file:
-    src:  "{{ ansible_env.HOME }}/.config/bash/.bashrc"
-    dest: "{{ ansible_env.HOME }}/.bashrc"
+    src:  "{{ ansible_facts['env']['HOME'] }}/.config/bash/.bashrc"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.bashrc"
     state: link
     force: true
 
 - name: Create .profile symlink
   ansible.builtin.file:
-    src:  "{{ ansible_env.HOME }}/.config/bash/.bash_profile"
-    dest: "{{ ansible_env.HOME }}/.profile"
+    src:  "{{ ansible_facts['env']['HOME'] }}/.config/bash/.bash_profile"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.profile"
     state: link
     force: true
 
 - name: Create .bash_profile symlink
   ansible.builtin.file:
-    src:  "{{ ansible_env.HOME }}/.config/bash/.bash_profile"
-    dest: "{{ ansible_env.HOME }}/.bash_profile"
+    src:  "{{ ansible_facts['env']['HOME'] }}/.config/bash/.bash_profile"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.bash_profile"
     state: link
     force: true
 
 - name: Add inputrc
   ansible.builtin.copy:
     src: inputrc
-    dest: "{{ ansible_env.HOME }}/.inputrc"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.inputrc"
 
 - name: Add mise config
   ansible.builtin.copy:
     src: mise.bash
-    dest: "{{ ansible_env.HOME }}/.config/bash/1_mise.bash"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/bash/1_mise.bash"
 

--- a/roles/bat/tasks/main.yml
+++ b/roles/bat/tasks/main.yml
@@ -1,48 +1,48 @@
 - name: Copy mise config
   ansible.builtin.copy:
     src: mise.toml
-    dest: "{{ ansible_env.HOME }}/.config/mise/conf.d/bat.toml"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/mise/conf.d/bat.toml"
 
 - name: Install
   ansible.builtin.command:
-    cmd: "{{ ansible_env.HOME }}/.local/bin/mise install"
+    cmd: "{{ ansible_facts['env']['HOME'] }}/.local/bin/mise install"
   changed_when: false
 
 - name: Ensure config directory
   ansible.builtin.file:
-    path: "{{ ansible_env.HOME }}/.config/bat/themes"
+    path: "{{ ansible_facts['env']['HOME'] }}/.config/bat/themes"
     state: directory
 
 - name: Add dark theme
   ansible.builtin.copy:
     src: "Catppuccin Mocha.tmTheme"
-    dest: "{{ ansible_env.HOME }}/.config/bat/themes/Catppuccin Mocha.tmTheme"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/bat/themes/Catppuccin Mocha.tmTheme"
   register: mocha_theme
 
 - name: Add light theme
   ansible.builtin.copy:
     src: "Catppuccin Latte.tmTheme"
-    dest: "{{ ansible_env.HOME }}/.config/bat/themes/Catppuccin Latte.tmTheme"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/bat/themes/Catppuccin Latte.tmTheme"
   register: latte_theme
 
 - name: Add config
   ansible.builtin.copy:
     src: config
-    dest: "{{ ansible_env.HOME }}/.config/bat/config"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/bat/config"
   register: bat_config
 
 - name: Rebuild bat cache
   ansible.builtin.command:
-    cmd: "{{ ansible_env.HOME }}/.local/share/mise/shims/bat cache --build"
+    cmd: "{{ ansible_facts['env']['HOME'] }}/.local/share/mise/shims/bat cache --build"
   when: mocha_theme.changed or latte_theme.changed or bat_config.changed
 
 - name: Add bash config
   ansible.builtin.copy:
     src: bat.bash
-    dest: "{{ ansible_env.HOME }}/.config/bash/bat.bash"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/bash/bat.bash"
 
 - name: Add nushell config
   ansible.builtin.copy:
     src: bat.nu
-    dest: "{{ ansible_env.HOME }}/.config/nushell/autoload/bat.nu"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/nushell/autoload/bat.nu"
 

--- a/roles/eza/tasks/main.yml
+++ b/roles/eza/tasks/main.yml
@@ -1,19 +1,19 @@
 - name: Copy mise config
   ansible.builtin.copy:
     src: mise.toml
-    dest: "{{ ansible_env.HOME }}/.config/mise/conf.d/eza.toml"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/mise/conf.d/eza.toml"
 
 - name: Install
   ansible.builtin.command:
-    cmd: "{{ ansible_env.HOME }}/.local/bin/mise install"
+    cmd: "{{ ansible_facts['env']['HOME'] }}/.local/bin/mise install"
   changed_when: false
 
 - name: Add bash config
   ansible.builtin.copy:
     src: eza.bash
-    dest: "{{ ansible_env.HOME }}/.config/bash/eza.bash"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/bash/eza.bash"
 
 - name: Add nu config
   ansible.builtin.copy:
     src: eza.nu
-    dest: "{{ ansible_env.HOME }}/.config/nushell/autoload/eza.nu"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/nushell/autoload/eza.nu"

--- a/roles/fd/tasks/main.yml
+++ b/roles/fd/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: Copy mise config
   ansible.builtin.copy:
     src: mise.toml
-    dest: "{{ ansible_env.HOME }}/.config/mise/conf.d/fd.toml"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/mise/conf.d/fd.toml"
 
 - name: Install
   ansible.builtin.command:
-    cmd: "{{ ansible_env.HOME }}/.local/bin/mise install"
+    cmd: "{{ ansible_facts['env']['HOME'] }}/.local/bin/mise install"
   changed_when: false

--- a/roles/fzf/tasks/main.yml
+++ b/roles/fzf/tasks/main.yml
@@ -1,20 +1,20 @@
 - name: Copy mise config
   ansible.builtin.copy:
     src: mise.toml
-    dest: "{{ ansible_env.HOME }}/.config/mise/conf.d/fzf.toml"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/mise/conf.d/fzf.toml"
 
 - name: Install
   ansible.builtin.command:
-    cmd: "{{ ansible_env.HOME }}/.local/bin/mise install"
+    cmd: "{{ ansible_facts['env']['HOME'] }}/.local/bin/mise install"
   changed_when: false
 
 - name: Add bash config
   ansible.builtin.copy:
     src: fzf.bash
-    dest: "{{ ansible_env.HOME }}/.config/bash/fzf.bash"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/bash/fzf.bash"
 
 - name: Add nushell config
   ansible.builtin.copy:
     src: fzf.nu
-    dest: "{{ ansible_env.HOME }}/.config/nushell/autoload/fzf.nu"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/nushell/autoload/fzf.nu"
 

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -7,43 +7,43 @@
 
 - name: Ensure config directory
   ansible.builtin.file:
-    path: "{{ ansible_env.HOME }}/.config/git"
+    path: "{{ ansible_facts['env']['HOME'] }}/.config/git"
     state: directory
 
 - name: Add gitconfig
   ansible.builtin.copy:
     src: gitconfig
-    dest: "{{ ansible_env.HOME }}/.gitconfig"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.gitconfig"
 
 - name: Add GitHub specific config
   ansible.builtin.copy:
     src: gitconfig-github.com
-    dest: "{{ ansible_env.HOME }}/.config/git/gitconfig-github.com"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/git/gitconfig-github.com"
 
 - name: Add GitLab.com specific config
   ansible.builtin.copy:
     src: gitconfig-gitlab.com
-    dest: "{{ ansible_env.HOME }}/.config/git/gitconfig-gitlab.com"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/git/gitconfig-gitlab.com"
 
 - name: Add global gitignore
   ansible.builtin.copy:
     src: gitignore
-    dest: "{{ ansible_env.HOME }}/.config/git/gitignore"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/git/gitignore"
 
 - name: Copy mise config
   ansible.builtin.copy:
     src: mise.toml
-    dest: "{{ ansible_env.HOME }}/.config/mise/conf.d/git.toml"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/mise/conf.d/git.toml"
 
 - name: Install delta
   ansible.builtin.command:
-    cmd: "{{ ansible_env.HOME }}/.local/bin/mise install"
+    cmd: "{{ ansible_facts['env']['HOME'] }}/.local/bin/mise install"
   changed_when: false
 
 - name: Add delta config
   ansible.builtin.copy:
     src: delta.gitconfig
-    dest: "{{ ansible_env.HOME }}/.config/git/delta.gitconfig"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/git/delta.gitconfig"
 
 - name: Check git version
   ansible.builtin.command: git --version
@@ -57,13 +57,13 @@
 - name: Install version-dependent config (2.35+)
   ansible.builtin.copy:
     src: conflict-style-modern.gitconfig
-    dest: "{{ ansible_env.HOME }}/.config/git/conflict-style.gitconfig"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/git/conflict-style.gitconfig"
   when: git_version is version('2.35', '>=')
   ignore_errors: true
 
 - name: Install version-dependent config (below 2.35)
   ansible.builtin.copy:
     src: conflict-style.gitconfig
-    dest: "{{ ansible_env.HOME }}/.config/git/conflict-style.gitconfig"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/git/conflict-style.gitconfig"
   when: git_version is version('2.35', '<')
   ignore_errors: true

--- a/roles/gnome/tasks/main.yml
+++ b/roles/gnome/tasks/main.yml
@@ -16,7 +16,7 @@
   ansible.builtin.pip:
     name: psutil
     state: latest
-    executable: "{{ ansible_env.HOME }}/.local/share/mise/shims/pip"
+    executable: "{{ ansible_facts['env']['HOME'] }}/.local/share/mise/shims/pip"
 
 # Dark Mode
 - name: Enable Dark Mode
@@ -48,27 +48,27 @@
 # Cursor Theme
 - name: Ensure icons Directory at .icons
   ansible.builtin.file:
-    path: "{{ ansible_env.HOME }}/.icons"
+    path: "{{ ansible_facts['env']['HOME'] }}/.icons"
     state: directory
 - name: Download Cursor Theme to .icons
   ansible.builtin.unarchive:
     src: https://github.com/catppuccin/cursors/releases/download/v2.0.0/catppuccin-mocha-blue-cursors.zip
-    dest: "{{ ansible_env.HOME }}/.icons/"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.icons/"
     remote_src: yes
-    creates: "{{ ansible_env.HOME }}/.icons/catppuccin-mocha-blue-cursors"
+    creates: "{{ ansible_facts['env']['HOME'] }}/.icons/catppuccin-mocha-blue-cursors"
 
   # It appears that some applications only respect the cursor theme in .local/share/icons while others only respect it in .icons
   # So we'll copy the theme to both locations to ensure it works everywhere
 - name: Ensure icons Directory at .local/share/icons
   ansible.builtin.file:
-    path: "{{ ansible_env.HOME }}/.local/share/icons"
+    path: "{{ ansible_facts['env']['HOME'] }}/.local/share/icons"
     state: directory
 - name: Download Cursor Theme to .local/share/icons
   ansible.builtin.unarchive:
     src: https://github.com/catppuccin/cursors/releases/download/v2.0.0/catppuccin-mocha-blue-cursors.zip
-    dest: "{{ ansible_env.HOME }}/.local/share/icons/"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.local/share/icons/"
     remote_src: yes
-    creates: "{{ ansible_env.HOME }}/.local/share/icons/catppuccin-mocha-blue-cursors"
+    creates: "{{ ansible_facts['env']['HOME'] }}/.local/share/icons/catppuccin-mocha-blue-cursors"
 
 - name: Set Icon Theme
   community.general.dconf:
@@ -77,40 +77,40 @@
 
 - name: Ensure Picture Directory
   ansible.builtin.file:
-    path: "{{ ansible_env.HOME }}/Pictures"
+    path: "{{ ansible_facts['env']['HOME'] }}/Pictures"
     state: directory
 
 - name: Download Light Mode Wallpaper
   ansible.builtin.get_url:
     url: "https://github.com/ll-nick/ansible-config/blob/main/roles/gnome/files/wallpaper-light.png?raw=true"
-    dest: "{{ ansible_env.HOME }}/Pictures/wallpaper-light.png"
+    dest: "{{ ansible_facts['env']['HOME'] }}/Pictures/wallpaper-light.png"
     checksum: sha256:4e6924667214a986274a61f84b8b202f776d758d51dfbc256fe9ab4954e66e9a
 
 - name: Download Dark Mode Wallpaper
   ansible.builtin.get_url:
     url: "https://github.com/ll-nick/ansible-config/blob/main/roles/gnome/files/wallpaper-dark.png?raw=true"
-    dest: "{{ ansible_env.HOME }}/Pictures/wallpaper-dark.png"
+    dest: "{{ ansible_facts['env']['HOME'] }}/Pictures/wallpaper-dark.png"
     checksum: sha256:1199a43751f1234d3fb92ecf614fbf34de2c07334d3fdd355891044f51bddada
 
 - name: Set Wallpaper
   community.general.dconf:
     key: "/org/gnome/desktop/background/picture-uri"
-    value: "'file:///{{ ansible_env.HOME }}/Pictures/wallpaper-light.png'"
+    value: "'file:///{{ ansible_facts['env']['HOME'] }}/Pictures/wallpaper-light.png'"
 
 - name: Set Dark Mode Wallpaper
   community.general.dconf:
     key: "/org/gnome/desktop/background/picture-uri-dark"
-    value: "'file:///{{ ansible_env.HOME }}/Pictures/wallpaper-dark.png'"
+    value: "'file:///{{ ansible_facts['env']['HOME'] }}/Pictures/wallpaper-dark.png'"
 
 # PaperWM
 - name: Copy mise config
   ansible.builtin.copy:
     src: mise.toml
-    dest: "{{ ansible_env.HOME }}/.config/mise/conf.d/gnome.toml"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/mise/conf.d/gnome.toml"
 
 - name: Install GNOME Extension CLI
   ansible.builtin.command:
-    cmd: "{{ ansible_env.HOME }}/.local/bin/mise install"
+    cmd: "{{ ansible_facts['env']['HOME'] }}/.local/bin/mise install"
   changed_when: false
 
 - name: Query installed GNOME extensions

--- a/roles/kitty/tasks/main.yml
+++ b/roles/kitty/tasks/main.yml
@@ -1,19 +1,19 @@
 - name: Copy mise config
   ansible.builtin.copy:
     src: mise.toml
-    dest: "{{ ansible_env.HOME }}/.config/mise/conf.d/kitty.toml"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/mise/conf.d/kitty.toml"
   # kitty is best installed via nixpkgs on NixOS
   when: ansible_distribution != "NixOS"
 
 - name: Install
   ansible.builtin.command:
-    cmd: "{{ ansible_env.HOME }}/.local/bin/mise install"
+    cmd: "{{ ansible_facts['env']['HOME'] }}/.local/bin/mise install"
   changed_when: false
   when: ansible_distribution != "NixOS"
 
 - name: Check if kitty desktop files are set up
   ansible.builtin.stat:
-    path: "{{ ansible_env.HOME }}/.local/share/applications/kitty.desktop"
+    path: "{{ ansible_facts['env']['HOME'] }}/.local/share/applications/kitty.desktop"
   register: kitty_desktop
 
 - name: Post-install tasks
@@ -21,35 +21,35 @@
   block:
   - name: Copy kitty.desktop to appropriate location
     ansible.builtin.copy:
-      src: "{{ ansible_env.HOME }}/.local/share/mise/installs/github-kovidgoyal-kitty/latest/share/applications/kitty.desktop"
-      dest: "{{ ansible_env.HOME }}/.local/share/applications/kitty.desktop"
+      src: "{{ ansible_facts['env']['HOME'] }}/.local/share/mise/installs/github-kovidgoyal-kitty/latest/share/applications/kitty.desktop"
+      dest: "{{ ansible_facts['env']['HOME'] }}/.local/share/applications/kitty.desktop"
 
   - name: Copy kitty-open.desktop to appropriate location
     ansible.builtin.copy:
-      src: "{{ ansible_env.HOME }}/.local/share/mise/installs/github-kovidgoyal-kitty/latest/share/applications/kitty-open.desktop"
-      dest: "{{ ansible_env.HOME }}/.local/share/applications/kitty-open.desktop"
+      src: "{{ ansible_facts['env']['HOME'] }}/.local/share/mise/installs/github-kovidgoyal-kitty/latest/share/applications/kitty-open.desktop"
+      dest: "{{ ansible_facts['env']['HOME'] }}/.local/share/applications/kitty-open.desktop"
 
   - name: Update Icon path in .desktop files
     ansible.builtin.shell:
-      cmd: "sed -i 's|Icon=kitty|Icon={{ ansible_env.HOME }}/.local/share/mise/installs/github-kovidgoyal-kitty/latest/share/icons/hicolor/256x256/apps/kitty.png|g' ~/.local/share/applications/kitty*.desktop"
+      cmd: "sed -i 's|Icon=kitty|Icon={{ ansible_facts['env']['HOME'] }}/.local/share/mise/installs/github-kovidgoyal-kitty/latest/share/icons/hicolor/256x256/apps/kitty.png|g' ~/.local/share/applications/kitty*.desktop"
     args:
       executable: /bin/bash
 
   - name: Update Exec path in .desktop files
     ansible.builtin.shell:
-      cmd: "sed -i 's|Exec=kitty|Exec={{ ansible_env.HOME }}/.local/share/mise/installs/github-kovidgoyal-kitty/latest/bin/kitty|g' ~/.local/share/applications/kitty*.desktop"
+      cmd: "sed -i 's|Exec=kitty|Exec={{ ansible_facts['env']['HOME'] }}/.local/share/mise/installs/github-kovidgoyal-kitty/latest/bin/kitty|g' ~/.local/share/applications/kitty*.desktop"
     args:
       executable: /bin/bash
 
   - name: Make xdg-terminal-exec use kitty
     ansible.builtin.lineinfile:
-      path: "{{ ansible_env.HOME }}/.config/xdg-terminals.list"
+      path: "{{ ansible_facts['env']['HOME'] }}/.config/xdg-terminals.list"
       line: 'kitty.desktop'
       create: yes
 
 - name: Clone Config
   ansible.builtin.git:
     repo: "{{ github_prefix }}ll-nick/kitty-config.git"
-    dest: "{{ ansible_env.HOME }}/.config/kitty"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/kitty"
   ignore_errors: true
 

--- a/roles/lazygit/tasks/main.yml
+++ b/roles/lazygit/tasks/main.yml
@@ -1,30 +1,30 @@
 - name: Copy mise config
   ansible.builtin.copy:
     src: mise.toml
-    dest: "{{ ansible_env.HOME }}/.config/mise/conf.d/lazygit.toml"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/mise/conf.d/lazygit.toml"
 
 - name: Install
   ansible.builtin.command:
-    cmd: "{{ ansible_env.HOME }}/.local/bin/mise install"
+    cmd: "{{ ansible_facts['env']['HOME'] }}/.local/bin/mise install"
   changed_when: false
 
 - name: Ensure config directory
   ansible.builtin.file:
-    path: "{{ ansible_env.HOME }}/.config/lazygit"
+    path: "{{ ansible_facts['env']['HOME'] }}/.config/lazygit"
     state: directory
 
 - name: Add lazygit config
   ansible.builtin.copy:
     src: config.yml
-    dest: "{{ ansible_env.HOME }}/.config/lazygit/config.yml"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/lazygit/config.yml"
 
 - name: Add bash config
   ansible.builtin.copy:
     src: lazygit.bash
-    dest: "{{ ansible_env.HOME }}/.config/bash/lazygit.bash"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/bash/lazygit.bash"
 
 - name: Add nushell config
   ansible.builtin.copy:
     src: lazygit.nu
-    dest: "{{ ansible_env.HOME }}/.config/nushell/autoload/lazygit.nu"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/nushell/autoload/lazygit.nu"
 

--- a/roles/leadr/tasks/main.yml
+++ b/roles/leadr/tasks/main.yml
@@ -1,23 +1,23 @@
 - name: Copy mise config
   ansible.builtin.copy:
     src: mise.toml
-    dest: "{{ ansible_env.HOME }}/.config/mise/conf.d/leadr.toml"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/mise/conf.d/leadr.toml"
 
 - name: Install
   ansible.builtin.command:
-    cmd: "{{ ansible_env.HOME }}/.local/bin/mise install"
+    cmd: "{{ ansible_facts['env']['HOME'] }}/.local/bin/mise install"
   changed_when: false
 
 - name: Clone config
   ansible.builtin.git:
     repo: "{{ github_prefix }}ll-nick/leadr-config"
-    dest: "{{ ansible_env.HOME }}/.config/leadr"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/leadr"
   ignore_errors: true
 
 - name: Add bash config
   ansible.builtin.copy:
     src: leadr.bash
-    dest: "{{ ansible_env.HOME }}/.config/bash/leadr.bash"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/bash/leadr.bash"
 
 - name: Generate init script
   ansible.builtin.command:
@@ -27,12 +27,12 @@
 
 - name: Write init file
   ansible.builtin.copy:
-    dest: "{{ ansible_env.HOME }}/.local/share/nushell/vendor/autoload/leadr.nu"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.local/share/nushell/vendor/autoload/leadr.nu"
     content: "{{ leadr_init.stdout }}"
     mode: "0644"
 
 - name: Write nushell env file
   ansible.builtin.copy:
     src: leadr_env.nu
-    dest: "{{ ansible_env.HOME }}/.local/share/nushell/vendor/autoload/leadr_env.nu"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.local/share/nushell/vendor/autoload/leadr_env.nu"
 

--- a/roles/mise/tasks/main.yml
+++ b/roles/mise/tasks/main.yml
@@ -1,16 +1,16 @@
 - name: Ensure ~/.local/bin exists
   ansible.builtin.file:
-    path: "{{ ansible_env.HOME }}/.local/bin"
+    path: "{{ ansible_facts['env']['HOME'] }}/.local/bin"
     state: directory
 
 - name: Install
   ansible.builtin.shell: |
     curl https://mise.jdx.dev/install.sh | sh
   args:
-    creates: "{{ ansible_env.HOME }}/.local/bin/mise"
+    creates: "{{ ansible_facts['env']['HOME'] }}/.local/bin/mise"
 
 - name: Ensure conf.d directory exists
   ansible.builtin.file:
-    path: "{{ ansible_env.HOME }}/.config/mise/conf.d"
+    path: "{{ ansible_facts['env']['HOME'] }}/.config/mise/conf.d"
     state: directory
 

--- a/roles/mrt/tasks/main.yml
+++ b/roles/mrt/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Add bash config
   ansible.builtin.copy:
     src: mrt.bash
-    dest: "{{ ansible_env.HOME }}/.config/bash/mrt.bash"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/bash/mrt.bash"
 
 - name: Check if mrt tools are installed
   ansible.builtin.stat:
@@ -14,10 +14,10 @@
     - name: Clone rossrc
       ansible.builtin.git:
         repo: "{{ github_prefix }}ll-nick/rossrc.git"
-        dest: "{{ ansible_env.HOME }}/.rossrc"
+        dest: "{{ ansible_facts['env']['HOME'] }}/.rossrc"
         force: true
 
     - name: Add mrtros bash config
       ansible.builtin.copy:
         src: mrtros.bash
-        dest: "{{ ansible_env.HOME }}/.config/bash/mrtros.bash"
+        dest: "{{ ansible_facts['env']['HOME'] }}/.config/bash/mrtros.bash"

--- a/roles/neovim/tasks/main.yml
+++ b/roles/neovim/tasks/main.yml
@@ -18,33 +18,33 @@
 - name: Copy mise config for newer glibc versions
   ansible.builtin.copy:
     src: mise-new-glibc.toml
-    dest: "{{ ansible_env.HOME }}/.config/mise/conf.d/neovim.toml"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/mise/conf.d/neovim.toml"
   when: glibc_version is version('2.32', '>=')
 
 - name: Copy mise config for older glibc versions
   ansible.builtin.copy:
     src: mise-old-glibc.toml
-    dest: "{{ ansible_env.HOME }}/.config/mise/conf.d/neovim.toml"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/mise/conf.d/neovim.toml"
   when: glibc_version is version('2.32', '<')
 
 - name: Install
   ansible.builtin.command:
-    cmd: "{{ ansible_env.HOME }}/.local/bin/mise install"
+    cmd: "{{ ansible_facts['env']['HOME'] }}/.local/bin/mise install"
   changed_when: false
 
 - name: Clone Config
   ansible.builtin.git:
     repo: "{{ github_prefix }}ll-nick/neovim-config.git"
-    dest: "{{ ansible_env.HOME }}/.config/nvim"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/nvim"
   ignore_errors: true
 
 - name: Add bash config
   ansible.builtin.copy:
     src: nvim.bash
-    dest: "{{ ansible_env.HOME }}/.config/bash/nvim.bash"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/bash/nvim.bash"
 
 - name: Add nushell config
   ansible.builtin.copy:
     src: nvim.nu
-    dest: "{{ ansible_env.HOME }}/.config/nushell/autoload/nvim.nu"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/nushell/autoload/nvim.nu"
 

--- a/roles/nerdfont/tasks/main.yml
+++ b/roles/nerdfont/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Ensure Fonts Directory
   ansible.builtin.file:
-    path: "{{ ansible_env.HOME }}/.local/share/fonts"
+    path: "{{ ansible_facts['env']['HOME'] }}/.local/share/fonts"
     state: directory
 
 - name: Install fontconfig
@@ -47,6 +47,6 @@
     - name: Download and Extract
       ansible.builtin.unarchive:
         src: "https://github.com/ryanoasis/nerd-fonts/releases/download/v{{ nerdfont_version }}/JetBrainsMono.zip"
-        dest: "{{ ansible_env.HOME }}/.local/share/fonts/"
+        dest: "{{ ansible_facts['env']['HOME'] }}/.local/share/fonts/"
         remote_src: yes
 

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -1,10 +1,10 @@
 - name: Copy mise config
   ansible.builtin.copy:
     src: mise.toml
-    dest: "{{ ansible_env.HOME }}/.config/mise/conf.d/nodejs.toml"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/mise/conf.d/nodejs.toml"
 
 - name: Install
   ansible.builtin.command:
-    cmd: "{{ ansible_env.HOME }}/.local/bin/mise install"
+    cmd: "{{ ansible_facts['env']['HOME'] }}/.local/bin/mise install"
   changed_when: false
 

--- a/roles/nushell/tasks/main.yml
+++ b/roles/nushell/tasks/main.yml
@@ -1,22 +1,22 @@
 - name: Copy mise config
   ansible.builtin.copy:
     src: mise.toml
-    dest: "{{ ansible_env.HOME }}/.config/mise/conf.d/nushell.toml"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/mise/conf.d/nushell.toml"
 
 - name: Install
   ansible.builtin.command:
-    cmd: "{{ ansible_env.HOME }}/.local/bin/mise install"
+    cmd: "{{ ansible_facts['env']['HOME'] }}/.local/bin/mise install"
   changed_when: false
 
 - name: Clone config
   ansible.builtin.git:
     repo: "{{ github_prefix }}ll-nick/nushell-config"
-    dest: "{{ ansible_env.HOME }}/.config/nushell"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/nushell"
   ignore_errors: true
 
 - name: Ensure autoload directory
   ansible.builtin.file:
-    path: "{{ ansible_env.HOME }}/.local/share/nushell/vendor/autoload"
+    path: "{{ ansible_facts['env']['HOME'] }}/.local/share/nushell/vendor/autoload"
     state: directory
 
 - name: Generate carapace init script
@@ -27,7 +27,7 @@
 
 - name: Write carapace init file
   ansible.builtin.copy:
-    dest: "{{ ansible_env.HOME }}/.local/share/nushell/vendor/autoload/carapace.nu"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.local/share/nushell/vendor/autoload/carapace.nu"
     content: "{{ carapace_init.stdout }}"
     mode: "0644"
 
@@ -39,6 +39,6 @@
 
 - name: Write mise init file
   ansible.builtin.copy:
-    dest: "{{ ansible_env.HOME }}/.local/share/nushell/vendor/autoload/00_mise.nu"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.local/share/nushell/vendor/autoload/00_mise.nu"
     content: "{{ mise_init.stdout }}"
     mode: "0644"

--- a/roles/ripgrep/tasks/main.yml
+++ b/roles/ripgrep/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: Copy mise config
   ansible.builtin.copy:
     src: mise.toml
-    dest: "{{ ansible_env.HOME }}/.config/mise/conf.d/ripgrep.toml"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/mise/conf.d/ripgrep.toml"
 
 - name: Install
   ansible.builtin.command:
-    cmd: "{{ ansible_env.HOME }}/.local/bin/mise install"
+    cmd: "{{ ansible_facts['env']['HOME'] }}/.local/bin/mise install"
   changed_when: false

--- a/roles/starship/tasks/main.yml
+++ b/roles/starship/tasks/main.yml
@@ -1,23 +1,23 @@
 - name: Copy mise config
   ansible.builtin.copy:
     src: mise.toml
-    dest: "{{ ansible_env.HOME }}/.config/mise/conf.d/starship.toml"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/mise/conf.d/starship.toml"
 
 - name: Install
   ansible.builtin.command:
-    cmd: "{{ ansible_env.HOME }}/.local/bin/mise install"
+    cmd: "{{ ansible_facts['env']['HOME'] }}/.local/bin/mise install"
   changed_when: false
 
 - name: Clone Config
   ansible.builtin.git:
     repo: "{{ github_prefix }}ll-nick/starship-config.git"
-    dest: "{{ ansible_env.HOME }}/.config/starship"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/starship"
   ignore_errors: true
 
 - name: Add bash config
   ansible.builtin.copy:
     src: prompt.bash
-    dest: "{{ ansible_env.HOME }}/.config/bash/prompt.bash"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/bash/prompt.bash"
 
 - name: Generate nushell init script
   ansible.builtin.command:
@@ -27,12 +27,12 @@
 
 - name: Write nushell init file
   ansible.builtin.copy:
-    dest: "{{ ansible_env.HOME }}/.local/share/nushell/vendor/autoload/starship.nu"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.local/share/nushell/vendor/autoload/starship.nu"
     content: "{{ starship_init.stdout }}"
     mode: "0644"
 
 - name: Add nushell config
   ansible.builtin.copy:
     src: starship.nu
-    dest: "{{ ansible_env.HOME }}/.config/nushell/autoload/starship.nu"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/nushell/autoload/starship.nu"
 

--- a/roles/tmux/tasks/main.yml
+++ b/roles/tmux/tasks/main.yml
@@ -9,51 +9,51 @@
 - name: Copy mise config
   ansible.builtin.copy:
     src: mise.toml
-    dest: "{{ ansible_env.HOME }}/.config/mise/conf.d/tmux.toml"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/mise/conf.d/tmux.toml"
 
 - name: Install
   ansible.builtin.command:
-    cmd: "{{ ansible_env.HOME }}/.local/bin/mise install"
+    cmd: "{{ ansible_facts['env']['HOME'] }}/.local/bin/mise install"
   changed_when: false
 
 - name: Clone Config
   ansible.builtin.git:
     repo: "{{ github_prefix }}ll-nick/tmux-config.git"
-    dest: "{{ ansible_env.HOME }}/.config/tmux"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/tmux"
   ignore_errors: true
   register: tmux_config
 
 - name: Clone TPM
   ansible.builtin.git:
     repo: "https://github.com/tmux-plugins/tpm"
-    dest: "{{ ansible_env.HOME }}/.config/tmux/plugins/tpm"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/tmux/plugins/tpm"
     force: true
 
 - name: Install Plugins
-  ansible.builtin.shell: "bash {{ ansible_env.HOME }}/.config/tmux/plugins/tpm/bin/install_plugins"
+  ansible.builtin.shell: "bash {{ ansible_facts['env']['HOME'] }}/.config/tmux/plugins/tpm/bin/install_plugins"
   when: tmux_config.changed
 
 - name: Add bash config
   ansible.builtin.copy:
     src: tmux.bash
-    dest: "{{ ansible_env.HOME }}/.config/bash/tmux.bash"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/bash/tmux.bash"
 
 - name: Add nushell config
   ansible.builtin.copy:
     src: tmux.nu
-    dest: "{{ ansible_env.HOME }}/.config/nushell/autoload/tmux.nu"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/nushell/autoload/tmux.nu"
 
 - when: ansible_service_mgr == "systemd"
   block:
     - name: Ensure systemd user service directory
       ansible.builtin.file:
-        path: "{{ ansible_env.HOME }}/.config/systemd/user"
+        path: "{{ ansible_facts['env']['HOME'] }}/.config/systemd/user"
         state: directory
 
     - name: Install autostart service
       ansible.builtin.copy:
         src: tmux.service
-        dest: "{{ ansible_env.HOME }}/.config/systemd/user/tmux.service"
+        dest: "{{ ansible_facts['env']['HOME'] }}/.config/systemd/user/tmux.service"
 
     - name: Enable autostart service
       ansible.builtin.systemd:

--- a/roles/tmux/tasks/main.yml
+++ b/roles/tmux/tasks/main.yml
@@ -43,7 +43,7 @@
     src: tmux.nu
     dest: "{{ ansible_facts['env']['HOME'] }}/.config/nushell/autoload/tmux.nu"
 
-- when: ansible_service_mgr == "systemd"
+- when: ansible_facts['service_mgr'] == "systemd"
   block:
     - name: Ensure systemd user service directory
       ansible.builtin.file:

--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -4,7 +4,7 @@
     dest: "{{ ansible_facts['env']['HOME'] }}/.local/bin/stk"
     mode: "0755"
 
-- when: has_display and ansible_service_mgr == "systemd"
+- when: has_display and ansible_facts['service_mgr'] == "systemd"
   block:
     - name: Ensure systemd user service directory
       ansible.builtin.file:

--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -1,25 +1,25 @@
 - name: Install script
   ansible.builtin.copy:
     src: stk
-    dest: "{{ ansible_env.HOME }}/.local/bin/stk"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.local/bin/stk"
     mode: "0755"
 
 - when: has_display and ansible_service_mgr == "systemd"
   block:
     - name: Ensure systemd user service directory
       ansible.builtin.file:
-        path: "{{ ansible_env.HOME }}/.config/systemd/user"
+        path: "{{ ansible_facts['env']['HOME'] }}/.config/systemd/user"
         state: directory
 
     - name: Install stk-check service
       ansible.builtin.copy:
         src: stk-check.service
-        dest: "{{ ansible_env.HOME }}/.config/systemd/user/stk-check.service"
+        dest: "{{ ansible_facts['env']['HOME'] }}/.config/systemd/user/stk-check.service"
 
     - name: Install stk-check timer
       ansible.builtin.copy:
         src: stk-check.timer
-        dest: "{{ ansible_env.HOME }}/.config/systemd/user/stk-check.timer"
+        dest: "{{ ansible_facts['env']['HOME'] }}/.config/systemd/user/stk-check.timer"
 
     - name: Enable stk-check timer
       ansible.builtin.systemd:

--- a/roles/uv/tasks/main.yml
+++ b/roles/uv/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: Copy mise config
   ansible.builtin.copy:
     src: mise.toml
-    dest: "{{ ansible_env.HOME }}/.config/mise/conf.d/uv.toml"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/mise/conf.d/uv.toml"
 
 - name: Install
   ansible.builtin.command:
-    cmd: "{{ ansible_env.HOME }}/.local/bin/mise install"
+    cmd: "{{ ansible_facts['env']['HOME'] }}/.local/bin/mise install"
   changed_when: false

--- a/roles/xdg_open/tasks/main.yml
+++ b/roles/xdg_open/tasks/main.yml
@@ -1,6 +1,6 @@
 # ── LOCAL MACHINE (has display) ────────────────────────────────────────────────
 
-- when: has_display and ansible_service_mgr == "systemd"
+- when: has_display and ansible_facts['service_mgr'] == "systemd"
   block:
     - name: Ensure systemd user service directory
       ansible.builtin.file:

--- a/roles/xdg_open/tasks/main.yml
+++ b/roles/xdg_open/tasks/main.yml
@@ -38,6 +38,7 @@
         for p in /usr/bin/xdg-open /usr/local/bin/xdg-open; do
           [ -x "$p" ] && echo "$p" && break
         done
+        true
       register: real_xdg_open_result
       changed_when: false
 

--- a/roles/xdg_open/tasks/main.yml
+++ b/roles/xdg_open/tasks/main.yml
@@ -4,19 +4,19 @@
   block:
     - name: Ensure systemd user service directory
       ansible.builtin.file:
-        path: "{{ ansible_env.HOME }}/.config/systemd/user"
+        path: "{{ ansible_facts['env']['HOME'] }}/.config/systemd/user"
         state: directory
 
     - name: Deploy socket unit
       ansible.builtin.template:
         src: ssh_remote_xdg_open.socket.j2
-        dest: "{{ ansible_env.HOME }}/.config/systemd/user/ssh_remote_xdg_open.socket"
+        dest: "{{ ansible_facts['env']['HOME'] }}/.config/systemd/user/ssh_remote_xdg_open.socket"
       notify: Reload and enable socket
 
     - name: Deploy service unit
       ansible.builtin.template:
         src: "ssh_remote_xdg_open@.service.j2"
-        dest: "{{ ansible_env.HOME }}/.config/systemd/user/ssh_remote_xdg_open@.service"
+        dest: "{{ ansible_facts['env']['HOME'] }}/.config/systemd/user/ssh_remote_xdg_open@.service"
 
     - name: Inject RemoteForward into SSH config
       ansible.builtin.script:
@@ -48,12 +48,12 @@
 
     - name: Ensure ~/.local/bin exists
       ansible.builtin.file:
-        path: "{{ ansible_env.HOME }}/.local/bin"
+        path: "{{ ansible_facts['env']['HOME'] }}/.local/bin"
         state: directory
 
     - name: Deploy xdg-open shim
       ansible.builtin.template:
         src: xdg_open_shim.py.j2
-        dest: "{{ ansible_env.HOME }}/.local/bin/xdg-open"
+        dest: "{{ ansible_facts['env']['HOME'] }}/.local/bin/xdg-open"
         mode: "0755"
       when: real_xdg_open_path | length > 0

--- a/roles/zoxide/tasks/main.yml
+++ b/roles/zoxide/tasks/main.yml
@@ -1,17 +1,17 @@
 - name: Copy mise config
   ansible.builtin.copy:
     src: mise.toml
-    dest: "{{ ansible_env.HOME }}/.config/mise/conf.d/zoxide.toml"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/mise/conf.d/zoxide.toml"
 
 - name: Install
   ansible.builtin.command:
-    cmd: "{{ ansible_env.HOME }}/.local/bin/mise install"
+    cmd: "{{ ansible_facts['env']['HOME'] }}/.local/bin/mise install"
   changed_when: false
 
 - name: Add bash config
   ansible.builtin.copy:
     src: zoxide.bash
-    dest: "{{ ansible_env.HOME }}/.config/bash/zoxide.bash"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/bash/zoxide.bash"
 
 - name: Generate nushell init script
   ansible.builtin.command:
@@ -21,6 +21,6 @@
 
 - name: Write nushell init file
   ansible.builtin.copy:
-    dest: "{{ ansible_env.HOME }}/.local/share/nushell/vendor/autoload/zoxide.nu"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.local/share/nushell/vendor/autoload/zoxide.nu"
     content: "{{ zoxide_init.stdout }}"
     mode: "0644"


### PR DESCRIPTION
This adds  a CI pipeline that will deploy the config inside a clean docker environment.
It uses a Dockerfile and a bash script which can also be executed locally for regression testing.

It fixes some issues I noticed along the way and all deprecation warnings. The latter causes a bit of noise in this PR since most changes are related to that.